### PR TITLE
migration context fixes

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 require './config/environment'
 
-if ActiveRecord::Migrator.needs_migration?
+if ActiveRecord::Base.connection.migration_context.needs_migration?
   raise 'Migrations are pending. Run `rake db:migrate` to resolve the issue.'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'rack/test'
 require 'capybara/rspec'
 require 'capybara/dsl'
 
-if ActiveRecord::Migrator.needs_migration?
+if ActiveRecord::Base.connection.migration_context.needs_migration?
   raise 'Migrations are pending. Run `rake db:migrate SINATRA_ENV=test` to resolve the issue.'
 end
 


### PR DESCRIPTION
This should fix an issue introduced by ActiveRecord 5 deprecating `needs_migration?`

This issue was unrelated to, but discovered during, the curriculum update to Ruby 2.6