### PR TITLE
fix errors involving old ar migrate needed, and tables not creating w…

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,8 +1,7 @@
 require './config/environment'
 
-if ActiveRecord::Migrator.needs_migration?
-  raise 'Migrations are pending. Run `rake db:migrate` to resolve the issue.'
+if ActiveRecord::Base.connection.migration_context.needs_migration?
+  raise 'Migrations are pending. Run `rake db:migrate SINATRA_ENV=test` to resolve the issue.'
 end
-
 
 run ApplicationController

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,10 @@
+default: &default
+  adapter: "sqlite3"
+  database: "db/development.sqlite"
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+  database: "db/test.sqlite"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,9 @@ require 'rack/test'
 require 'capybara/rspec'
 require 'capybara/dsl'
 
-if ActiveRecord::Migrator.needs_migration?
-  raise 'Migrations are pending. Run `rake db:migrate` to resolve the issue.'
+if ActiveRecord::Base.connection.migration_context.needs_migration?
+  raise 'Migrations are pending. Run `rake db:migrate SINATRA_ENV=test` to resolve the issue.'
 end
-
 
 ActiveRecord::Base.logger = nil
 


### PR DESCRIPTION
Having a lot of students with newer versions of active record getting an error for needs migration, fix can be found here: https://stackoverflow.com/questions/50790649/nomethoderror-undefined-method-needs-migration-for-activerecordmigratorcl

other students seem to be affected by the lack of the database.yml file, added that as well 